### PR TITLE
Adding support for bad rows with less than 8 fields

### DIFF
--- a/parsePdftables.py
+++ b/parsePdftables.py
@@ -40,11 +40,7 @@ def readPDF(filename ,headers):
 	pdfFileObj = open(filename, 'rb')
 	pdfReader = pypdf.PdfFileReader(pdfFileObj)
 	print("log: Found {} pages".format(pdfReader.numPages))
-	# pagesText = []
-	# for i in range(0, pdfReader.numPages):
-	# 	pageData = pdfReader.getPage(i)
-	# 	pageText = pageData.extractText()
-	# 	pagesText.append(pageText)
+
 
 	pagesText = map(lambda i: pdfReader.getPage(i).extractText() ,range(0, pdfReader.numPages))
 


### PR DESCRIPTION
Due to the unstructured nature of the files, some of the rows picked up do not conform to the splitting rule. Hence had to introduce a check for illegal access of indices in the row array. Also fixed the text used for filtering the pages.